### PR TITLE
Consistent and simplified naming of Key related variables

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -812,9 +812,8 @@ described in {{MP_KEY}}, while the HMAC "Message" for MP_JOIN, MP_ADDADDR and MP
    * for MP_JOIN: The nonces of the MP_JOIN messages for which authentication
    shall be performed. Depending on whether Host A or Host B performs the HMAC-SHA256 calculation, it is carried out as follows:
 
-   MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=RA+RB)
-   
-   MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=RB+RA)
+        * MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=RA+RB)
+        * MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=RB+RA)
    
    An usage example is shown in {{ref-mp-dccp-handshaking}}.
 
@@ -823,17 +822,15 @@ described in {{MP_KEY}}, while the HMAC "Message" for MP_JOIN, MP_ADDADDR and MP
    order (NBO). Depending on whether Host A or Host B performs the HMAC-SHA256 calculation,
    it is carried out as follows:
 
-   MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID+NBO(IP)+NBO(Port))
-   
-   MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID+NBO(IP)+NBO(Port))
+        * MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID+NBO(IP)+NBO(Port))
+        * MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID+NBO(IP)+NBO(Port))
    
    * for MP_REMOVEADDR: Solely the Address ID.
    Depending on whether Host A or Host B performs the HMAC-SHA256 calculation,
    it is carried out as follows:
 
-   MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID)
-   
-   MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID)
+        * MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID)
+        * MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID)
 
 MP_JOIN, MP_ADDADDR and MP_REMOVEADDR can co-exist or be used multiple times
 within a single DCCP packet. All these multipath options require an individual

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -700,7 +700,7 @@ Host B will then tear down all subflows and terminate the MP-DCCP connection.
 {: #ref-MP_KEY title='Format of the MP_KEY suboption'}
 
 The MP_KEY suboption is used to exchange a Connection Identifier (CI) and key material between
-hosts for a given connection.
+hosts (hostA, hostB) for a given connection.
 The CI is a unique number that is configured per host during the initial exchange of a connection with MP_KEY and is necessary to connect other DCCP subflows to an MP-DCCP connection with MP_JOIN ({{MP_JOIN}}). Its size of 32-bits also defines the maximum number of simultaneous MP-DCCP connections in a host to 2^32.
 According to the Key related elements of the MP_KEY suboption, the Length varies between 17 and 73 Bytes for a single-key message, and up to
 115 Bytes when all specified Key Types 0-2 are provided. The Key Type field 
@@ -717,10 +717,12 @@ The set of key types are shown in {{ref-key-type-list}}.
 
 
 Plain Text
-: Key Material is exchanged in plain text between hosts, and the key
-  parts (key-a, key-b) are used by each host to generate the derived
+: Key Material is exchanged in plain text between hosts (Host A, Host B), and the respective key
+  parts (KeyA, KeyB) are used by each host to generate the derived
   key (d-key) by concatenating the two parts with the local key
-  in front (e.g. hostA d-key(A)=(key-a+key-b), hostB d-key(B)=(key-b+key-a)).
+  in front. That is,
+  * Host A d-keyA=(KeyA+KeyB)
+  * Host B d-keyB=(KeyB+KeyA)).
 {: vspace='0'}
 
 
@@ -808,22 +810,22 @@ described in {{MP_KEY}}, while the HMAC "Message" for MP_JOIN, MP_ADDADDR and MP
 
    * for MP_JOIN: The nonces of the MP_JOIN messages for which authentication
    shall be performed. Depending on whether Host A or Host B performs the HMAC-SHA256 calculation, it is carried out as follows:
-   MP_HMAC(A) = HMAC-SHA256(Key=d-key(A), Msg=RA+RB)
-   MP_HMAC(B) = HMAC-SHA256(Key=d-key(B), Msg=RB+RA)
+   MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=RA+RB)
+   MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=RB+RA)
    An usage example is shown in {{ref-mp-dccp-handshaking}}.
 
    * for MP_ADDADDR: The Address ID with associated IP address and if defined port,
    otherwise two octets of value 0. IP address and port MUST be used in network byte
    order (NBO). Depending on whether Host A or Host B performs the HMAC-SHA256 calculation,
    it is carried out as follows:
-   MP_HMAC(A) = HMAC-SHA256(Key=d-key(A), Msg=Address ID+NBO(IP)+NBO(Port))
-   MP_HMAC(B) = HMAC-SHA256(Key=d-key(B), Msg=Address ID+NBO(IP)+NBO(Port))
+   MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID+NBO(IP)+NBO(Port))
+   MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID+NBO(IP)+NBO(Port))
    
    * for MP_REMOVEADDR: Solely the Address ID.
    Depending on whether Host A or Host B performs the HMAC-SHA256 calculation,
    it is carried out as follows:
-   MP_HMAC(A) = HMAC-SHA256(Key=d-key(A), Msg=Address ID)
-   MP_HMAC(B) = HMAC-SHA256(Key=d-key(B), Msg=Address ID)
+   MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID)
+   MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID)
 
 MP_JOIN, MP_ADDADDR and MP_REMOVEADDR can co-exist or be used multiple times
 within a single DCCP packet. All these multipath options require an individual
@@ -947,8 +949,8 @@ authentication. The truncated HMAC parameter present in this MP_HMAC
 option is the leftmost 20 bytes of an HMAC, negotiated and calculated
 as described in {{MP_HMAC}}. In the same way as for MP_JOIN,
 the key for the HMAC algorithm, in the case of the message transmitted
-by Host A, will be Key-A followed by Key-B, and in the case of Host B,
-Key-B followed by Key-A.  These are the keys that were exchanged and
+by Host A, will be KeyA followed by KeyB, and in the case of Host B,
+KeyB followed by KeyA.  These are the keys that were exchanged and
 selected in the original MP_KEY handshake. The message for the HMAC is
 the Address ID, IP address, and port number that precede the HMAC in the
 MP_ADDADDR option.  If the port number is not present in the MP_ADDADDR option,
@@ -1054,8 +1056,8 @@ authentication. The truncated HMAC parameter present in this MP_HMAC
 option is the leftmost 20 bytes of an HMAC, negotiated and calculated
 as described in {{MP_HMAC}}. In the same way as for MP_JOIN,
 the key for the HMAC algorithm, in the case of the message transmitted
-by Host A, will be Key-A followed by Key-B, and in the case of Host B,
-Key-B followed by Key-A.  These are the keys that were exchanged and
+by Host A, will be KeyA followed by KeyB, and in the case of Host B,
+KeyB followed by KeyA.  These are the keys that were exchanged and
 selected in the original MP_KEY handshake. The message for the HMAC is
 the Address ID.
 
@@ -1249,8 +1251,8 @@ Address A1    Address A2                              Address B1
 ----------    ----------                              ----------
      |             |                                       |
      |           DCCP-Request + Change R (MP_CAPABLE,...)  |
-     |---- MP_KEY(CI-A + Key-A(1), Key-A(2),...) --------->|
-     |<------------------- MP_KEY(CI-B + Key-B) -----------|
+     |----- MP_KEY(CI-A + KeyA(1), KeyA(2),...) ---------->|
+     |<------------------- MP_KEY(CI-B + KeyB) ------------|
      |       DCCP-Response +  Confirm L (MP_CAPABLE, ...)  |
      |             |                                       |
      |   DCCP-Ack  |                                       |
@@ -1273,12 +1275,12 @@ Address A1    Address A2                              Address B1
 The basic initial handshake for the first subflow is as follows:
 
 * Host A sends a DCCP-Request with the MP-Capable feature Change
-  request and the MP_KEY option with a Host-specific CI-A and a Key-A for
+  request and the MP_KEY option with a Host-specific CI-A and a KeyA for
   each of the supported key types as described in {{MP_KEY}}. CI-A is a unique identifier during the
   lifetime of a MP-DCCP connection.
 
 * Host B sends a DCCP-Response with Confirm feature for
-  MP-Capable and the MP_Key option with a unique Host-specific CI-B and a single Host-specific Key-B.
+  MP-Capable and the MP_Key option with a unique Host-specific CI-B and a single Host-specific KeyB.
   The type of the key is chosen from the list of supported types
   from the previous request.
 
@@ -1306,14 +1308,14 @@ handshake is as follows:
   of a HMAC code created by using the nonce received with MP_JOIN(A) and the
   local nonce RB as message and the derived key described in {{MP_KEY}} as key:
 
-  MP_HMAC(B) = HMAC-SHA256(Key=d-key(B), Msg=RB+RA)
+  MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=RB+RA)
 
 * Host A sends a DCCP-Ack with the HMAC computed for the DCCP-Response.
   The HMAC is calculated by taking the leftmost 20 bytes from the SHA256 hash
   of a HMAC code created by using the local nonce RA and the nonce received
   with MP_JOIN(B) as message and the derived key described in {{MP_KEY}} as key:
 
-  MP_HMAC(A) = HMAC-SHA256(Key=d-key(A), Msg=RA+RB)
+  MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=RA+RB)
 
 * Host B sends a DCCP-Ack to confirm the HMAC and to conclude the
   handshaking.
@@ -1459,7 +1461,7 @@ version is used. Reception of a non-verifiable MP_HMAC ({{MP_HMAC}}) or an inval
 CI used in MP_JOIN ({{MP_JOIN}}) during flow establishment MUST cause the
 subflow to be closed.
 
-The subflow closing procedure MUST be also applied if a final ACK carrying MP_KEY with wrong Key-A/Key-B is
+The subflow closing procedure MUST be also applied if a final ACK carrying MP_KEY with wrong KeyA/KeyB is
 received or MP_KEY option is malformed.
 
 Another relevant case is when payload data is modified by middleboxes. DCCP uses 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -722,8 +722,8 @@ Plain Text
   key (d-key) by concatenating the two parts with the local key
   in front. That is,
   
-  * Host A d-keyA=(KeyA+KeyB)
-  * Host B d-keyB=(KeyB+KeyA)
+  * Host A: d-keyA=(KeyA+KeyB)
+  * Host B: d-keyB=(KeyB+KeyA)
 {: vspace='0'}
 
 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -700,7 +700,7 @@ Host B will then tear down all subflows and terminate the MP-DCCP connection.
 {: #ref-MP_KEY title='Format of the MP_KEY suboption'}
 
 The MP_KEY suboption is used to exchange a Connection Identifier (CI) and key material between
-hosts (hostA, hostB) for a given connection.
+hosts (host A, host B) for a given connection.
 The CI is a unique number that is configured per host during the initial exchange of a connection with MP_KEY and is necessary to connect other DCCP subflows to an MP-DCCP connection with MP_JOIN ({{MP_JOIN}}). Its size of 32-bits also defines the maximum number of simultaneous MP-DCCP connections in a host to 2^32.
 According to the Key related elements of the MP_KEY suboption, the Length varies between 17 and 73 Bytes for a single-key message, and up to
 115 Bytes when all specified Key Types 0-2 are provided. The Key Type field 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -721,8 +721,9 @@ Plain Text
   parts (KeyA, KeyB) are used by each host to generate the derived
   key (d-key) by concatenating the two parts with the local key
   in front. That is,
+  
   * Host A d-keyA=(KeyA+KeyB)
-  * Host B d-keyB=(KeyB+KeyA)).
+  * Host B d-keyB=(KeyB+KeyA)
 {: vspace='0'}
 
 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -811,21 +811,28 @@ described in {{MP_KEY}}, while the HMAC "Message" for MP_JOIN, MP_ADDADDR and MP
 
    * for MP_JOIN: The nonces of the MP_JOIN messages for which authentication
    shall be performed. Depending on whether Host A or Host B performs the HMAC-SHA256 calculation, it is carried out as follows:
+
    MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=RA+RB)
+   
    MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=RB+RA)
+   
    An usage example is shown in {{ref-mp-dccp-handshaking}}.
 
    * for MP_ADDADDR: The Address ID with associated IP address and if defined port,
    otherwise two octets of value 0. IP address and port MUST be used in network byte
    order (NBO). Depending on whether Host A or Host B performs the HMAC-SHA256 calculation,
    it is carried out as follows:
+
    MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID+NBO(IP)+NBO(Port))
+   
    MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID+NBO(IP)+NBO(Port))
    
    * for MP_REMOVEADDR: Solely the Address ID.
    Depending on whether Host A or Host B performs the HMAC-SHA256 calculation,
    it is carried out as follows:
+
    MP_HMAC(A) = HMAC-SHA256(Key=d-keyA, Msg=Address ID)
+   
    MP_HMAC(B) = HMAC-SHA256(Key=d-keyB, Msg=Address ID)
 
 MP_JOIN, MP_ADDADDR and MP_REMOVEADDR can co-exist or be used multiple times


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.2.4: I find the notation confusing: hostA d-key(A)=(key-a+key-b).
Further, the use of "-" as part of the variable name is easy to confuse
with a math operator.  I suggest that the paragraph be reworded to show
how to compute key_d_a and key_d_b, which also avoids the key names
looking like functions.  Maybe:

   Key Material is exchanged in plain text between hosts, and the key
   parts (key_a, key_b) are used to generate the derived key (key_d)
   by concatenating the two parts with the local key in front.
   That is, key_d_a=key_a+key_b, and key_d_b=key_b+key_a.

If you accept this comment, then you might define the following:
   *  HMAC(A) = HMAC-SHA256(key_d_a, message)
   *  HMAC(B) = HMAC-SHA256(key_d_b, message)
```