### PR TITLE
No mandatory Key Type better explained

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -743,7 +743,9 @@ Multiple keys are only permitted in the DCCP-Request message
 of the handshake procedure for the first subflow. This allows the hosts to agree
 on a single key type to be used, as described in {{handshaking}}
 
-It is possible that not all hosts will have all key types. If the key type cannot be agreed in the 
+It is possible that not all hosts have all key types and this specification does not
+recommend or enforce the use of any particular Key Type as this could have security
+implications. If the key type cannot be agreed in the 
 handshake procedure, the MP-DCCP connection MUST fall back to not using MP-DCCP, as 
 indicated in {{fallback}}.
 


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.2.4: Is one of the Key Type mandatory-to-implement?  I realize
that does not make that Key Type mandatory-to-use.
```