### PR TITLE
More explicit description of the HMAC calculation

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -803,8 +803,8 @@ the HMAC code is generated according to {{RFC2104}} in combination
 with the SHA256 hash algorithm described in {{RFC6234}}, with the
 output truncated to the leftmost 160 bits (20 bytes).
 
-The "Key" used for the HMAC computation is the derived key (d-key)
-described in {{MP_KEY}}, while the HMAC "Message" for MP_JOIN, MP_ADDADDR and MP_REMOVEADDR is a concatenation of:
+The "Key" used for the HMAC computation is the derived key (d-keyA for Host A or d-KeyB for Host B)
+described in {{MP_KEY}}, while the HMAC "Message" for MP_JOIN, MP_ADDADDR and MP_REMOVEADDR must be calculated in both hosts in order to protect on the one hand and validate on the other, and is a concatenation of:
 
    * for MP_JOIN: The nonces of the MP_JOIN messages for which authentication
    shall be performed. Depending on whether Host A or Host B performs the HMAC-SHA256 calculation, it is carried out as follows:


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.2.6: The "Key" used for the HMAC computation is the derived
key (d-key) described in Section 3.2.4.  This statement is ambiguous.
In the proposed rewording of Section 3.2.4, the two keys values are
key_d_a and key_d_b.  Which one is used here?  The answer appears in
the bullets that follow, but it would be more clear to say it one time
before the bullets.  Further, both Hast A and Host B need to "perform"
the HMAC-SHA256 calculation.  One host is doing it to compute the value
to include in the datagram, and the other is doing it to check the value
that was received.
```