### PR TITLE
Better explanation of MPDCCP version 0 support

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -450,7 +450,10 @@ for version 1.
 
 3. MP-DCCP is then enabled between the Client and Server with version 1.
 
-Unlike the example in {{ref-mp-capable-example}}, this document only allows the negotiation of MP-DCCP version 0, which means that client and server must support it.
+Unlike the example in {{ref-mp-capable-example}}, this document only allows the
+negotiation of MP-DCCP version 0.  Therefore, successful
+negotiation of MP-DCCP as defined in this document, the client
+and the server MUST both support MP-DCCP version 0.
 
 If the version negotiation fails or the MP_CAPABLE feature is not present in the DCCP-Request or DCCP-Response packets of the initial handshake procedure, the MP-DCCP connection SHOULD fallback to regular DCCP or MUST close the connection. Further details are specified in {{fallback}}
 


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.1: The text says:

   Unlike the example in Figure 4, this document only allows the
   negotiation of MP-DCCP version 0, which means that client and server
   must support it.

I think it would be more clear to say:

   Unlike the example in Figure 4, this document only allows the
   negotiation of MP-DCCP version 0.  Therefore, successful
   negotiation of MP-DCCP as defined in this document, the client
   and the server MUST both support MP-DCCP version 0.
```