### PR TITLE
Certification authority fixed and reference added

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -82,6 +82,7 @@ informative:
   RFC3711:
   RFC4043:
   RFC5238:
+  RFC5280:
   RFC5596:
   RFC5597:
   RFC6356:
@@ -730,7 +731,7 @@ ECDHE-SHA256-C25519
   The full potential of ECDHE use is realized when it is combined with peer
   authentication technologies to protect against men-in-the-middle attacks. This can
   be achieved, for example, with separate use and verification of certificates
-  issued by a certificate authority.
+  issued by a certification authority (CA) as described in {{RFC5280}}.
 {: vspace='0'}
 
 


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.2.4: s/certificate authority/certification authority (CA)/
Also, you may want to reference [RFC 5280](https://datatracker.ietf.org/doc/rfc5280/) for a definition of a CA.
```