### PR TITLE
Improved description of when address advertisements are useful or not

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -995,7 +995,7 @@ information for a connection. Note that an implementation
 MAY discard incoming address advertisements. Reasons for this are for example:
 
 * to avoid the required mapping state, or
-* because advertised addresses are of no use to is.
+* because advertised addresses are of no use to it.
 
 Possible scenarios in which this applies are the lack of resources to store
 a mapping or when IPv6 addresses are advertised even though the host only

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -992,11 +992,16 @@ Address-ID-to-address mappings for a connection (identified by a CI
 pair). In this way, there is a stored mapping between the Address ID,
 the observed source address, and the CI pair for future processing of control
 information for a connection. Note that an implementation
-MAY discard incoming address advertisements - for example, to
-avoid the required mapping state, or because advertised addresses
-are of no use to it (for example, IPv6 addresses when it has IPv4
-only).  Therefore, a host MUST treat address advertisements as soft
-state, and the sender MAY choose to refresh advertisements periodically.
+MAY discard incoming address advertisements. Reasons for this are for example:
+
+* to avoid the required mapping state, or
+* because advertised addresses are of no use to is.
+
+Possible scenarios in which this applies are the lack of resources to store
+a mapping or when IPv6 addresses are advertised even though the host only
+supports IPv4. Therefore, a host MUST treat address announcements as soft state.
+However, a sender MAY choose to update the announcements periodically to
+overcome temporary limitations.
 
 A host
 MAY advertise private addresses, e.g., because there is a 


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.2.8:  The text says:

   ...  Note that an
   implementation MAY discard incoming address advertisements - for
   example, to avoid the required mapping state, or because advertised
   addresses are of no use to it (for example, IPv6 addresses when it
   has IPv4 only).  Therefore, a host MUST treat address advertisements
   as soft state, and the sender MAY choose to refresh advertisements
   periodically.

The nesting of examples makes this paragraph very difficult.  First,
please separate the MUST statement and the MAY statement.  Then, offer
examples to explain the reasons an implementation might choose to
discard incoming address advertisements or refresh advertisements
periodically.
```