### PR TITLE
Updated outdated description of the used Key material for MP_REMOVEAD…

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -481,7 +481,7 @@ The fields used by the multipath option are described in {{ref-mp-option-list}}.
 | 46  |       23      |  5 =MP_HMAC      | HMA Code for authentication                          |
 | 46  |       12      |  6 =MP_RTT       | Transmit RTT values                                  |
 | 46  |       var     |  7 =MP_ADDADDR   | Advertise additional Address                         |
-| 46  |       4       |  8 =MP_REMOVEADDR| Remove Address                                       |
+| 46  |       4       |  8 =VEADDR| Remove Address                                       |
 | 46  |       4       |  9 =MP_PRIO      | Change subflow Priority                              |
 | 46  |       var     | 10 =MP_CLOSE     | Close an MP-DCCP subflow                             |
 | 46  |       var     | 11 =MP_EXP       | Experimental for private use                         |
@@ -512,7 +512,7 @@ receiving host is not the subject of MP_CONFIRM.
 
 Multipath options could arrive out-of-order, therefore multipath options defined in {{ref-mp-option-confirm}}
 MUST be sent in a DCCP datagram with MP_SEQ {{MP_SEQ}}. This allows a receiver to identify whether
-multipath options are associated with obsolete datasets (information carried in the option header) that would otherwise conflict with newer datasets. In the case of MP_ADDADDR or MP_REMOVEADDR the same dataset is identified based on AddressID, whereas the same dataset for MP_PRIO is identified by the subflow in use. An outdated
+multipath options are associated with obsolete datasets (information carried in the option header) that would otherwise conflict with newer datasets. In the case of MP_ADDADDR or VEADDR the same dataset is identified based on AddressID, whereas the same dataset for MP_PRIO is identified by the subflow in use. An outdated
 multipath option is detected at the receiver if a previous multipath option referring to the same dataset contained a higher sequence number
 in the MP_SEQ. An MP_CONFIRM MAY be generated for multipath options that are identified as outdated.
 
@@ -530,7 +530,7 @@ once. This could happen if a datagram with MP_PRIO and a first MP_SEQ_1 and anot
 received in short succession. In this case, the structure described above is concatenated resulting in MP_SEQ_2 + MP_ADDADDR + MP_SEQ_1 + MP_PRIO.
 The order of the confirmed multipath options in the list of confirmations MUST reflect the incoming order at the host who sends the MP_CONFIRM, with the most
 recent suboption received listed first. This could allow the host receiving the MP_CONFIRM to verify that the options were applied in the correct order
-and to take countermeasures if they were not, e.g., if an MP_REMOVEADDR overtakes an MP_ADDADDR that refers to the same dataset.
+and to take countermeasures if they were not, e.g., if an VEADDR overtakes an MP_ADDADDR that refers to the same dataset.
 
 
 
@@ -947,8 +947,8 @@ authentication. The truncated HMAC parameter present in this MP_HMAC
 option is the leftmost 20 bytes of an HMAC, negotiated and calculated
 as described in {{MP_HMAC}}. In the same way as for MP_JOIN,
 the key for the HMAC algorithm, in the case of the message transmitted
-by Host A, will be Key-A followed by Key-B, and in the case of Host B,
-Key-B followed by Key-A.  These are the keys that were exchanged and
+by Host A, will be dKeyA, and in the case of Host B,
+dKeyB.  These are the keys that were exchanged and
 selected in the original MP_KEY handshake. The message for the HMAC is
 the Address ID, IP address, and port number that precede the HMAC in the
 MP_ADDADDR option.  If the port number is not present in the MP_ADDADDR option,
@@ -1054,8 +1054,8 @@ authentication. The truncated HMAC parameter present in this MP_HMAC
 option is the leftmost 20 bytes of an HMAC, negotiated and calculated
 as described in {{MP_HMAC}}. In the same way as for MP_JOIN,
 the key for the HMAC algorithm, in the case of the message transmitted
-by Host A, will be Key-A followed by Key-B, and in the case of Host B,
-Key-B followed by Key-A.  These are the keys that were exchanged and
+by Host A, will be d-keyA, and in the case of Host B,
+dKeyB.  These are the keys that were exchanged and
 selected in the original MP_KEY handshake. The message for the HMAC is
 the Address ID.
 


### PR DESCRIPTION
…DR/ADDADDR

Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

```
Section 3.2.9: Different names are used for the inputs to compute the
HMAC key in this section.  Please be consistent.
```