### PR TITLE
added a 4-tuple exampe for IPv4 and IPv6

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -233,6 +233,7 @@ similar to {{RFC8684}}, as follows:
  
 Path: A sequence of links between a sender and a receiver, defined in
 this context by a 4-tuple of source and destination address/port pairs. This is illustrated in the following two examples for IPv6 and IPv4, which each show a pair of sender IP-address:port and a pair of receiver IP-address:port, which together form the 4-tuple:
+
  * IPv6: [2001:db8:3333:4444:5555:6666:7777:8888]:1234, [2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:4321
  * IPv4: 203.0.113.1:1234, 203.0.113.2:4321
 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -232,7 +232,7 @@ for multipath transport or are defined in the context of MP-DCCP,
 similar to {{RFC8684}}, as follows:
  
 Path: A sequence of links between a sender and a receiver, defined in
-this context by a 4-tuple of source and destination address/port pairs. This is illustrated in the following two examples for IPv6 and IPv4, which each show a pair of sender IP-address:port and a pair of receiver IP-address:port, which together form the 4-tuple:
+this context by a 4-tuple of source and destination address and the source and destination ports. This is illustrated in the following two examples for IPv6 and IPv4, which each show a pair of sender IP-address:port and a pair of receiver IP-address:port, which together form the 4-tuple:
 
  * IPv6: [2001:db8:3333:4444:5555:6666:7777:8888]:1234, [2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:4321
  * IPv4: 203.0.113.1:1234, 203.0.113.2:4321

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -232,7 +232,9 @@ for multipath transport or are defined in the context of MP-DCCP,
 similar to {{RFC8684}}, as follows:
  
 Path: A sequence of links between a sender and a receiver, defined in
-this context by a 4-tuple of source and destination address/port pairs.
+this context by a 4-tuple of source and destination address/port pairs. This is illustrated in the following two examples for IPv6 and IPv4, which each show a pair of sender IP-address:port and a pair of receiver IP-address:port, which together form the 4-tuple:
+ * IPv6: [2001:db8:3333:4444:5555:6666:7777:8888]:1234, [2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:4321
+ * IPv4: 203.0.113.1:1234, 203.0.113.2:4321
 
 Subflow: A subflow refers to a DCCP flow transmitted using a specific path (4-tuple of source and destination address/port
 pairs) that forms one of the multipath flows used by a single connection.


### PR DESCRIPTION
Addresses [ART review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-artart-lc-housley-2024-10-04/) comment:

`Section 1.2: Please consider adding a definition of 4-tuple.`