### PR TITLE
Explain randomness of IDSN

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -764,7 +764,10 @@ indicated in {{fallback}}.
 
 The MP_SEQ suboption is used for end-to-end 48-bit datagram-based sequence
 numbers of an MP-DCCP connection. The initial data sequence
-number (IDSN) SHOULD be set randomly {{RFC4086}}. 
+number (IDSN) SHOULD be set randomly {{RFC4086}}. As with the standard DCCP
+sequence number, the data sequence number should not start at zero, but at
+a random value to make blind session hijacking more difficult, see also
+section 7.2 in {{RFC4340}}.
 
 The MP_SEQ number space is
 independent from the path individual sequence number space and MUST be


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
The discussion of requirements on "random" things, such as the nonces would
benefit from more precision. Bare pointers to 4086 aren't helpful. Discuss
why the IDNS should be set randomly.
```