### PR TITLE
Added discussion about advertising for non-unicast IP addresses

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1002,7 +1002,10 @@ A host
 MAY advertise private addresses, e.g., because there is a 
 NAT on the path.  It is
 desirable to allow this, since there could be cases where both hosts
-have additional interfaces on the same private network. 
+have additional interfaces on the same private network. The advertisement
+of broadcast or multicast IP addresses MUST be ignored by the recipient of
+this option, as it is not permitted according to the unicast principle of the
+basic DCCP.
 
 The MP_JOIN handshake to
 create a new subflow ({{MP_JOIN}}) provides mechanisms to minimize


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
Consider discussion what to do if a peer signals use of special addresses
(broadcast for example) in MP_ADDADDR.
```