### PR TITLE
"Locally unqiue" CI better explained

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -241,7 +241,7 @@ pairs) that forms one of the multipath flows used by a single connection.
 application can communicate between two hosts. The MP-DCCP connection is
 exposed as single DCCP socket to the application.
 
-Connection Identifier (CI): A unique identifier that is assigned to a multipath connection by the host in order to distinguish several multipath connections locally. The CIs must therefore be locally unique per host and do not have to be the same across the peers.
+Connection Identifier (CI): A unique identifier that is assigned to a multipath connection by the host to distinguish several multipath connections locally. The CIs must therefore be locally unique per host and do not have to be the same across the peers.
 
 Host: An end host operating an MP-DCCP implementation, and either
 initiating or accepting an MP-DCCP connection. 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -241,8 +241,7 @@ pairs) that forms one of the multipath flows used by a single connection.
 application can communicate between two hosts. The MP-DCCP connection is
 exposed as single DCCP socket to the application.
 
-Connection Identifier (CI): A locally unique identifier given to a multipath connection by a
-host.
+Connection Identifier (CI): A locally unique identifier in a host that is assigned to a multipath connection by the host to separate multiple multipath connections.
 
 Host: An end host operating an MP-DCCP implementation, and either
 initiating or accepting an MP-DCCP connection. 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -241,7 +241,7 @@ pairs) that forms one of the multipath flows used by a single connection.
 application can communicate between two hosts. The MP-DCCP connection is
 exposed as single DCCP socket to the application.
 
-Connection Identifier (CI): A locally unique identifier in a host that is assigned to a multipath connection by the host to separate multiple multipath connections.
+Connection Identifier (CI): A unique identifier that is assigned to a multipath connection by the host in order to distinguish several multipath connections locally. The CIs must therefore be locally unique per host and do not have to be the same across the peers.
 
 Host: An end host operating an MP-DCCP implementation, and either
 initiating or accepting an MP-DCCP connection. 


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
At the definition of Connection Identifier, "locally unique" is not a
sufficient description of what's required of the identifier.
```