### PR TITLE
Better formulation of the details of path management

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -350,9 +350,8 @@ Address A1    Address A2             Address B1    Address B2
 
    *  The discovery and setup of additional subflows is achieved
       through a path management method including the logic and details of the procedures for adding/removing subflows;
-      this document describes measures to allow a host to initiate new subflows and signal available addresses 
-      between peers. The definition of a path management method is, however, out of scope of this document and subject to a 
-      corresponding policy and the specifics of the implementation. If a MP-DCCP peer host limits  the maximum number of paths that can be maintained (e.g., similar to what is discussed in Section 3.4 of {{RFC8041}}, the creation of new subflows from that peer host needs to be avoided by terminating incoming subflow requests.
+      this document describes the procedures that enable a host to initiate new subflows or to signal available IP addresses between peers. However, the definition of a path management method, in which sequence and when subflows are created, is outside the scope of this document. This method is subject to a 
+      corresponding policy and the specifics of the implementation. If a MP-DCCP peer host wishes to limit the maximum number of paths that can be maintained (e.g. similar to that discussed in section 3.4 of {{RFC8041}}), the creation of new subflows from that peer host must be avoided by terminating incoming subflow requests.
 
    *  Through the use of multipath options, MP-DCCP adds connection-level sequence numbers and exchange of
       Round-Trip Time (RTT) information to enable optional reordering features. As a hint for scheduling decisions, a multipath option that allows a peer to indicate its priorities for what path to use is also defined.

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -351,7 +351,7 @@ Address A1    Address A2             Address B1    Address B2
    *  The discovery and setup of additional subflows is achieved
       through a path management method including the logic and details of the procedures for adding/removing subflows;
       this document describes the procedures that enable a host to initiate new subflows or to signal available IP addresses between peers. However, the definition of a path management method, in which sequence and when subflows are created, is outside the scope of this document. This method is subject to a 
-      corresponding policy and the specifics of the implementation. If a MP-DCCP peer host wishes to limit the maximum number of paths that can be maintained (e.g. similar to that discussed in section 3.4 of {{RFC8041}}), the creation of new subflows from that peer host must be avoided by terminating incoming subflow requests.
+      corresponding policy and the specifics of the implementation. If a MP-DCCP peer host wishes to limit the maximum number of paths that can be maintained (e.g. similar to that discussed in section 3.4 of {{RFC8041}}), the creation of new subflows from that peer host MUST be avoided and incoming subflow requests MUST be terminated.
 
    *  Through the use of multipath options, MP-DCCP adds connection-level sequence numbers and exchange of
       Round-Trip Time (RTT) information to enable optional reordering features. As a hint for scheduling decisions, a multipath option that allows a peer to indicate its priorities for what path to use is also defined.

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -349,9 +349,9 @@ Address A1    Address A2             Address B1    Address B2
       alternatively have been initiated from B1 or B2.
 
    *  The discovery and setup of additional subflows is achieved
-      through a path management method including the logic and details of the procedures for adding/removing subflows;
-      this document describes the procedures that enable a host to initiate new subflows or to signal available IP addresses between peers. However, the definition of a path management method, in which sequence and when subflows are created, is outside the scope of this document. This method is subject to a 
-      corresponding policy and the specifics of the implementation. If a MP-DCCP peer host wishes to limit the maximum number of paths that can be maintained (e.g. similar to that discussed in section 3.4 of {{RFC8041}}), the creation of new subflows from that peer host MUST be avoided and incoming subflow requests MUST be terminated.
+      through a path management method including the logic and details of the procedures for adding/removing subflows.
+      This document describes the procedures that enable a host to initiate new subflows or to signal available IP addresses between peers. However, the definition of a path management method, in which sequence and when subflows are created, is outside the scope of this document. This method is subject to a 
+      corresponding policy and the specifics of the implementation. If a MP-DCCP peer host wishes to limit the maximum number of paths that can be maintained (e.g. similar to that discussed in section 3.4 of {{RFC8041}}), the creation of new subflows from that peer host is omitted when the threshold of maximum paths is exceeded and incoming subflow requests MUST be rejected.
 
    *  Through the use of multipath options, MP-DCCP adds connection-level sequence numbers and exchange of
       Round-Trip Time (RTT) information to enable optional reordering features. As a hint for scheduling decisions, a multipath option that allows a peer to indicate its priorities for what path to use is also defined.


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
The first sentence on page 4 (staring "The discovery and setup") does not parse.

Is "needs to be avoided" in the last sentence of that paragraph masking a
normative requirement?
```