### PR TITLE
Clarification that new MP feature extends DCCP feature list

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -363,7 +363,7 @@ Address A1    Address A2             Address B1    Address B2
 # MP-DCCP Protocol {#protocol}
 
 The DCCP protocol feature list ({{Section 6.4 of RFC4340}}) is
-updated by adding  a new Multipath feature with Feature number 10, as
+extended in this document by adding a new Multipath feature with Feature number 10, as
 shown in {{ref-feature-list}}.
 
 | Number       | Meaning                      | Rec'n Rule | Initial Value | Req'd |


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
At the first paragraph of section 3, the document claims it is updating section
6.4 of RFC4340. I don't believe this document is doing such a thing. It is,
rather, adding an entry to an IANA registry, and the prose should say that
instead.
```