### PR TITLE
Resolved unclear SHOULD MUST construction

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -452,7 +452,7 @@ for version 1.
 
 Unlike the example in {{ref-mp-capable-example}}, this document only allows the negotiation of MP-DCCP version 0, which means that client and server must support it.
 
-If the version negotiation fails or the MP_CAPABLE feature is not present in the DCCP-Request or DCCP-Response packets of the initial handshake procedure, the MP-DCCP connection SHOULD fallback to regular DCCP or MUST close the connection. Further details are specified in {{fallback}}
+If the version negotiation fails or the MP_CAPABLE feature is not present in the DCCP-Request or DCCP-Response packets of the initial handshake procedure, the MP-DCCP connection MUST either fallback to regular DCCP or MUST close the connection. Further details are specified in {{fallback}}
 
 
 ## Multipath Option {#MP_OPT}


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
At the first paragraph on page 11, SHOULD A or MUST B is an unclear
construction. I think you mean "MUST either A (which is preferred) or B".
```