### PR TITLE
Improved language when describing the confirmation of obsolete options

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -506,9 +506,12 @@ These operations are largely inspired by the signals defined in {{RFC8684}}.
 ~~~~
 {: #ref-mp-confirm-format title='Format of the MP_CONFIRM option'}
 
-Some multipath options require confirmation from the remote peer (see {{ref-mp-option-confirm}}). Such options will be retransmitted by the sender 
-until an MP_CONFIRM is received or the confirmation of options is considered irrelevant because the data is outdated. The further processing of the multipath options in the
-receiving host is not the subject of MP_CONFIRM.
+Some multipath options require confirmation from the remote peer (see {{ref-mp-option-confirm}}).
+Such options will be retransmitted by the sender until an MP_CONFIRM is received or the confirmation
+of options is considered irrelevant because the data contained in the options has already been
+replaced by newer information. This can happen, for example, with an MP_PRIO option if the path prioritization
+is changed while the previous prioritization has not yet been confirmed. The further processing
+of the multipath options in the receiving host is not the subject of MP_CONFIRM.
 
 Multipath options could arrive out-of-order, therefore multipath options defined in {{ref-mp-option-confirm}}
 MUST be sent in a DCCP datagram with MP_SEQ {{MP_SEQ}}. This allows a receiver to identify whether

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -507,7 +507,7 @@ These operations are largely inspired by the signals defined in {{RFC8684}}.
 {: #ref-mp-confirm-format title='Format of the MP_CONFIRM option'}
 
 Some multipath options require confirmation from the remote peer (see {{ref-mp-option-confirm}}). Such options will be retransmitted by the sender 
-until an MP_CONFIRM is received or confirmation of options is identified outdated. The further processing of the multipath options in the
+until an MP_CONFIRM is received or the confirmation of options is considered irrelevant because the data is outdated. The further processing of the multipath options in the
 receiving host is not the subject of MP_CONFIRM.
 
 Multipath options could arrive out-of-order, therefore multipath options defined in {{ref-mp-option-confirm}}


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

`Page 13: "confirmation of options is identified outdated" fails to parse.`