### PR TITLE
Normative language in MP_FAST_CLOSE procedure

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -671,13 +671,13 @@ using a DCCP-Reset packet with Reset Code 13. The requirement to send the MP_FAS
 the selected Key Data of the peer host during the handshaking procedure 
 is carried by the MP_FAST_CLOSE option. 
 
-After sending the MP_FAST_CLOSE on all subflows, host A will tear down all subflows 
+After sending the MP_FAST_CLOSE on all subflows, host A MUST tear down all subflows 
 and the multipath DCCP connection immediately terminates.
 
 Upon reception of the first MP_FAST_CLOSE with successfully validated 
 Key Data, host B will send a DCCP-Reset packet response on all subflows to 
 host A with Reset Code 13 to clean potential middlebox states. 
-Host B will then tear down all subflows and terminate the MP-DCCP connection. 
+Host B MUST then tear down all subflows and terminate the MP-DCCP connection. 
 
 
 ### MP_KEY {#MP_KEY}


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
The document uses "tear down the connection" informally. Please consider
removing all such language and say instead what that means (in most instances
it's already been said).
```