### PR TITLE
s/have/support/ in key types text

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -743,7 +743,7 @@ Multiple keys are only permitted in the DCCP-Request message
 of the handshake procedure for the first subflow. This allows the hosts to agree
 on a single key type to be used, as described in {{handshaking}}
 
-It is possible that not all hosts will have all key types. If the key type cannot be agreed in the 
+It is possible that not all hosts will support all key types. If the key type cannot be agreed in the 
 handshake procedure, the MP-DCCP connection MUST fall back to not using MP-DCCP, as 
 indicated in {{fallback}}.
 


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

`Page 19 at "not all hosts will have all key types" : suggest s/have/support/`