### PR TITLE
Better description of the MP_HMAC exception to be ignored

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -841,8 +841,8 @@ cannot be validated by a receiving host because the HMAC validation fails, the s
 on which suboption was being verified. If the suboption to be authenticated was either
 MP_ADDADDR or MP_REMOVEADDR, the receiving host MUST silently ignore it (see {{MP_ADDADDR}} and {{MP_REMOVEADDR}}). 
 If the suboption to be authenticated was MP_JOIN, the subflow MUST be closed (see {{fallback}}).
-In the event that an MP_HMAC cannot be associated with a suboption, unless it is the single MP_HMAC that is sent
-in DCCP-Ack after a DCCP response packet with MP_JOIN ({{handshaking}}), this MP_HMAC MUST be ignored.
+In the event that an MP_HMAC cannot be associated with a suboption this MP_HMAC MUST be ignored, unless
+it is a single MP_HMAC that was sent in a DCCP-Ack corresponding to a DCCP response packet with MP_JOIN ({{handshaking}}).
 
 ### MP_RTT {#MP_RTT}
 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -841,8 +841,8 @@ cannot be validated by a receiving host because the HMAC validation fails, the s
 on which suboption was being verified. If the suboption to be authenticated was either
 MP_ADDADDR or MP_REMOVEADDR, the receiving host MUST silently ignore it (see {{MP_ADDADDR}} and {{MP_REMOVEADDR}}). 
 If the suboption to be authenticated was MP_JOIN, the subflow MUST be closed (see {{fallback}}).
-In the event that an MP_HMAC cannot be associated with a suboption, unless it is an MP_HMAC sent
-in DCCP-Ack in response to a DCCP-Response packet containing an MP_JOIN option, this MP_HMAC MUST be ignored.
+In the event that an MP_HMAC cannot be associated with a suboption, unless it is the single MP_HMAC that is sent
+in DCCP-Ack after a DCCP response packet with MP_JOIN ({{handshaking}}), this MP_HMAC MUST be ignored.
 
 ### MP_RTT {#MP_RTT}
 


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
The exception in the last sentence of 3.2.6 is not clear. Consider a
restructure where you can make it clear what you are supposed to do with an
MP_HMAC that cannot be associated with a suboption when it is in a DCCP-Ack
in response to a DCCP-Response packet containing an MP_JOIN option at this
point in the text.
```