### PR TITLE
SHOULD to MUST ignore MP_ADDADDR with invalid MP_HAMC

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -958,7 +958,7 @@ injecting MP_ADDADDR signals in an attempt to hijack a connection.
 Note that, additionally, the presence of this HMAC prevents the
 address from being changed in flight unless the key is known by an
 intermediary.  If a host receives an MP_ADDADDR option for which it
-cannot validate the HMAC, it SHOULD silently ignore the option.
+cannot validate the HMAC, it MUST silently ignore the option.
 
 The presence of an MP_SEQ {{MP_SEQ}} MUST be ensured in a DCCP datagram
 in which MP_ADDADDR is sent, as described in {{MP_CONFIRM}}.


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
Page 25, 3rd paragraph - why "SHOULD silently ignore". When would you do
something else?
```