### PR TITLE
Corrected wrong order of paragraphs which explain the refresh of conn…

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1025,19 +1025,19 @@ The reception of an MP_ADDADDR message is acknowledged using MP_CONFIRM
 ({{MP_CONFIRM}}). This ensures reliable exchange of address
 information.
 
-A host MAY send an MP_ADDADDR message with an already assigned Address
-ID, but the Address MUST be the same as previously assigned to this
-Address ID, and the Port MUST be different from one already in use
-for this Address ID.  If these conditions are not met, the receiver
-SHOULD silently ignore the MP_ADDADDR.  A host wishing to replace an
-existing Address ID MUST first remove the existing one ({{MP_REMOVEADDR}}).
-
 A host that receives an MP_ADDADDR, but finds at connection set up
 that the IP address and port number is unsuccessful, SHOULD NOT perform
 further connection attempts to this address/port combination for this
-connection. However, a sender that wishes to trigger a new incoming
+connection. If a sender, however, wishes to trigger a new incoming
 connection attempt on a previously advertised address/port combination
 can therefore refresh the MP_ADDADDR information by sending the option again.
+
+A host MAY send therefore an MP_ADDADDR message with an already assigned Address
+ID, but the IP Address MUST be the same as previously assigned to this
+Address ID. A new MP_ADDADDR may have the same port number or a different port number. 
+If these conditions are not met, the receiver
+MUST silently ignore the MP_ADDADDR.  A host wishing to replace an
+existing Address ID MUST first remove the existing one ({{MP_REMOVEADDR}}).
 
 
 ### MP_REMOVEADDR {#MP_REMOVEADDR}


### PR DESCRIPTION
…ection attempts

Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
Page 25, last paragraph of 3.2.8 - It's unclearly stated that receiving a
resent MP_ADDADDR overrides the SHOULD NOT perform further connection attempts.
Is it the intent that a host SHOULD retry each time it receives such a resent
message?
```