### PR TITLE
MP_PRIO removed unecessary SHOULD

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1102,8 +1102,8 @@ information, see {{closing}}.
 
 ### MP_PRIO {#MP_PRIO}
 
-The path priority signaled with the MP_PRIO option are hints 
-for the packet scheduler when making decisions which path to use for 
+The path priority signaled with the MP_PRIO option provides hints 
+for the packet scheduler when making decisions about which path to use for 
 payload traffic.
 When a single specific path from the set of available
 paths is treated with higher priority compared to the others

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1102,7 +1102,7 @@ information, see {{closing}}.
 
 ### MP_PRIO {#MP_PRIO}
 
-The path priority SHOULD be considered as hints 
+The path priority signaled with the MP_PRIO options are hints 
 for the packet scheduler when making decisions which path to use for 
 payload traffic.
 When a single specific path from the set of available

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1102,7 +1102,7 @@ information, see {{closing}}.
 
 ### MP_PRIO {#MP_PRIO}
 
-The path priority signaled with the MP_PRIO options are hints 
+The path priority signaled with the MP_PRIO option are hints 
 for the packet scheduler when making decisions which path to use for 
 payload traffic.
 When a single specific path from the set of available


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
At 3.2.10, the use of a capitalized SHOULD is not appropriate. It would be
better to say "The path priorities signaled with the MP_PRIO option are hints".
```