### PR TITLE
s/priority flag/priority value/

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1116,7 +1116,7 @@ could also change, for example, when a mobile host runs out
 of battery, the usage of only a single path may be the preferred choice
 of the user. 
 
-The MP_PRIO suboption, shown below, can be used to set a priority flag
+The MP_PRIO suboption, shown below, can be used to set a priority value
 for the subflow over which the suboption is received.
 
 ~~~~


### PR DESCRIPTION
Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
In 3.2.10 you say "priority flag" exactly once. Suggest s/priority
flag/priority value/.
```