### PR TITLE
MUST fallback or close instead of SHOULD if MP version cannot be nego…

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1443,7 +1443,7 @@ messages do not carry the MP_CAPABLE feature, the MP-DCCP connection will not be
 established and the handshake SHOULD fallback to regular DCCP (if this is not 
 possible it MUST be closed). 
 
-A connection SHOULD fallback to regular DCCP if the endpoints fail to agree on a
+A connection MUST either fallback to regular DCCP or closed if the endpoints fail to agree on a
 protocol version to use during the Multipath Capable feature negotiation. This is described in
 {{mp_capable}}. The protocol version negotiation distinguishes between negotiation
 for the initial connection establishment, and addition of subsequent subflows. If

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1443,12 +1443,12 @@ messages do not carry the MP_CAPABLE feature, the MP-DCCP connection will not be
 established and the handshake SHOULD fallback to regular DCCP (if this is not 
 possible it MUST be closed). 
 
-A connection MUST either fallback to regular DCCP or closed if the endpoints fail to agree on a
-protocol version to use during the Multipath Capable feature negotiation. This is described in
-{{mp_capable}}. The protocol version negotiation distinguishes between negotiation
-for the initial connection establishment, and addition of subsequent subflows. If
-protocol version negotiation is not successful during the initial connection establishment,
-MP-DCCP connection will fallback to regular DCCP. 
+If the endpoints fail to agree on the protocol version to use during the Multipath
+Capable feature negotiation, the connection MUST either be closed or fallback
+to regular DCCP. This is described in {{mp_capable}}. The protocol version negotiation
+distinguishes between negotiation for the initial connection establishment, and
+addition of subsequent subflows. If protocol version negotiation is not successful
+during the initial connection establishment, MP-DCCP connection will fallback to regular DCCP. 
 
 The fallback procedure to regular DCCP MUST be also applied if the MP_KEY {{MP_KEY}} Key Type cannot be negotiated.
 


### PR DESCRIPTION
…tiated

Addresses [GEN review](https://datatracker.ietf.org/doc/review-ietf-tsvwg-multipath-dccp-17-genart-lc-sparks-2024-10-17/) comment:

```
Top of page 36 - why is this SHOULD? What would happen otherwise. Is this
another example of MUST either do A or B, where A is preferred and B is
currently implicit?
```